### PR TITLE
Add --fallback-architecture option

### DIFF
--- a/src/ubuntu_package_download/cli.py
+++ b/src/ubuntu_package_download/cli.py
@@ -32,6 +32,8 @@ def main(
         Annotated[bool, typer.Option(help="If the exact version cannot be found in the specified Ubuntu series should we query earlier Ubuntu series?")] = True,
     fallback_version:
         Annotated[bool, typer.Option(help="If the exact version cannot be found should we download the next version?")] = False,
+    fallback_architecture:
+        Annotated[bool, typer.Option(help="If the exact architecture cannot be found should we fallback to the default architecture?")] = True,
     ):
     """Console script for ubuntu_package_download."""
     console.print(f"Package name is {package_name}")
@@ -41,11 +43,12 @@ def main(
     console.print(f"Series is {series}")
     console.print(f"Fallback series is {fallback_series}")
     console.print(f"Fallback version is {fallback_version}")
+    console.print(f"Fallback architecture is {fallback_architecture}")
 
     level = logging.getLevelName(logging_level)
     logging.basicConfig(level=level, stream=sys.stderr, format="%(asctime)s [%(levelname)s] %(message)s")
 
-    download_deb(package_name, package_version, package_architecture, series, fallback_series, fallback_version)
+    download_deb(package_name, package_version, package_architecture, series, fallback_series, fallback_version, fallback_architecture)
 
 
 if __name__ == "__main__":

--- a/src/ubuntu_package_download/lib.py
+++ b/src/ubuntu_package_download/lib.py
@@ -49,14 +49,14 @@ def _get_binary_build(archive, launchpad, lp_arch_series, package_name,
 
 
 def download_deb(
-    package_name, package_version, package_architecture="amd64", series=None, fallback_series=True, fallback_version=False):
+    package_name, package_version, package_architecture="amd64", series=None, fallback_series=True, fallback_version=False, fallback_architecture=True):
     """
     Download a deb from launchpad for a specific package version and architecture
 
     Process/Order of finding the package and fallback logic:
 
     1. Attempt to find the package in the specified series and architecture
-    2. If the package is not found in the specified series and architecture attempt to find the package in the `all` architecture (amd64)
+    2. If the package is not found in the specified series and architecture attempt to find the package in the `all` architecture (amd64) if fallback_architecture flag is set to True
     3. If the package is not found in the `all` architecture attempt to find the package in a previous series if the fallback_series flag is set to True
     4. If the package is not found in a previous series attempt to find the previous version of the package in the same series if the fallback_version flag is set to True
 
@@ -204,11 +204,11 @@ def download_deb(
         # This will be our fallback if we do not find a build for the specified architecture. Typically this is
         # the `all` architecture
         architecture_all_arch_tag = "amd64"
-        if package_architecture != architecture_all_arch_tag:
+        if package_architecture != architecture_all_arch_tag and fallback_architecture:
             print(
                 f"WARNING: \tFALLBACK ARCHITECTURE - Attempting to find and download the {package_name} {architecture_all_arch_tag} version {package_version}..."
             )
-            download_deb(package_name, package_version, package_architecture=architecture_all_arch_tag, series=series, fallback_series=fallback_series, fallback_version=fallback_version)
+            download_deb(package_name, package_version, package_architecture=architecture_all_arch_tag, series=series, fallback_series=fallback_series, fallback_version=fallback_version, fallback_architecture=fallback_architecture)
 
 
 def _perform_download(binary_build, binary_publishing_history, launchpad, lp_series):


### PR DESCRIPTION
We make use of  `ubuntu-package-download` to download packages and their build dependencies. The behavior where the tool defaults to `amd64` when a package for the specified architecture(e.g. `riscv64`) is not found is a little problematic as it can produce inconsistent results.

So, I am proposing to add a new flag `--fallback-architecture` which defaults to True which is same as current implementation. But if this is set to `False`, then the tool does not try to download the package for `amd64` whenever package for specified arch(e.g `riscv64`) is not found.